### PR TITLE
Implement RuboCop recommendations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ end
 
 RuboCop::RakeTask.new
 
-task :default => :test
+task default: :test

--- a/bin/webmention
+++ b/bin/webmention
@@ -1,59 +1,68 @@
 #!/usr/bin/env ruby
 
-$:.unshift(File.join(File.dirname(__FILE__), "/../lib"))
-require "webmention"
-require "link_header"
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-url = ARGV[0]
-
-if url == nil
-  puts "Usage: webmention http://example.com/post/100"
-  exit 1
-end
-
-if !Webmention::Client.valid_http_url?(url)
-  puts "Not a valid URL"
-  exit 1
-end
-
-client = Webmention::Client.new url
+require 'link_header'
+require 'webmention'
 
 def debug(msg)
   puts msg
 end
 
-debug "Finding links on #{url}"
+url = ARGV[0]
+
+if url.nil?
+  puts 'Usage: webmention https://source.example.com/post/100'
+  exit 1
+end
+
+unless Webmention::Client.valid_http_url?(url)
+  puts "`#{url}` is not a valid URL."
+  exit 1
+end
+
+client = Webmention::Client.new(url)
+
+debug("Crawling `#{url}` for links...")
+
 client.crawl
 
 links = client.links
-debug "Found #{links.length} links:"
-debug links.to_a.map{|m| "\t#{m}"}.join("\n")
 
-debug ""
+debug("Links found: #{links.length}")
+debug(links.to_a.map { |link| "\t#{link}" }.join("\n"))
+
+debug('')
 
 links.each do |link|
-  debug link
+  debug(link)
 
   endpoint = Webmention::Client.supports_webmention?(link)
-  if endpoint
-    debug "\tDiscovered Webmention endpoint:"
-    debug "\t#{endpoint}"
-    debug "\tSending webmention..."
-    result = Webmention::Client.send_mention endpoint, url, link, true
-    if result
-      debug "\tReturned HTTP #{result.code}"
-      if result.headers['link']
-        link_headers = LinkHeader.parse result.headers['link']
-        if status_link = link_headers.find_link(['rel', 'status'])
-          debug "\tWebmention status: #{status_link.href}"
-        end
-      end
-    else
-      debug "\tEncountered an unknown error sending this webmention!"
-    end
-  else
-    debug "\tNo webmention endpoint found"
+
+  unless endpoint
+    debug("\tNo webmention endpoint found at `#{link}`.")
+    next
   end
 
-  debug ""
+  debug("\tDiscovered webmention endpoint: #{endpoint}")
+  debug("\tSending webmention...")
+
+  result = Webmention::Client.send_mention(endpoint, url, link, true)
+
+  unless result
+    debug("\tEncountered an unknown error sending this webmention!")
+    next
+  end
+
+  debug("\tHTTP status code: #{result.code}")
+
+  link_headers = result.headers['link']
+
+  if link_headers
+    status_link = LinkHeader.parse(link_headers).find_link(%w[rel status])
+
+    debug("\tWebmention status URL: #{status_link.href}") if status_link
+  end
+
+  debug ''
 end

--- a/lib/webmention/version.rb
+++ b/lib/webmention/version.rb
@@ -1,3 +1,3 @@
 module Webmention
-  VERSION = "0.1.6"
+  VERSION = '0.1.6'.freeze
 end

--- a/webmention.gemspec
+++ b/webmention.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'webmention/version'


### PR DESCRIPTION
This pull request implements _a lot_ of the recommendations made by [RuboCop](http://rubocop.readthedocs.io) (run with `bundle exec rubocop` from the root of the project).

## Background

RuboCop is a static code analysis tool that identifies complex or otherwise gnarly code and makes suggestions based on the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide). Not all of its recommendations are always appropriate, but I've had more luck with it than without.

## Before

> 8 files inspected, 105 offenses detected

<details>
  <summary>View console output from <code>bundle exec rubocop</code></summary>

  ```sh
  Inspecting 8 files
  CCC.W.WC

  Offenses:

  webmention.gemspec:1:12: C: Style/ExpandPathArguments: Use expand_path('lib', __dir__) instead of expand_path('../lib', __FILE__).
  lib = File.expand_path('../lib', __FILE__)
             ^^^^^^^^^^^
  example.rb:9:1: C: Layout/EmptyLines: Extra blank line detected. (https://github.com/rubocop-hq/ruby-style-guide#two-or-more-empty-lines)
  example.rb:11:10: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  target = "http://indiewebcamp.com/"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  example.rb:13:12: C: Layout/TrailingWhitespace: Trailing whitespace detected. (https://github.com/rubocop-hq/ruby-style-guide#no-trailing-whitespace)
  if endpoint 
             ^
  example.rb:14:45: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
    Webmention::Client.send_mention endpoint, "http://source.example.com/post/100", target
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  example.rb:17:1: C: Layout/EmptyLines: Extra blank line detected. (https://github.com/rubocop-hq/ruby-style-guide#two-or-more-empty-lines)
  example.rb:19:33: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  Webmention::Client.send_mention "http://webmention.io/example/webmention", "http://source.example.com/post/100", "http://target.example.com/post/100"
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  example.rb:19:76: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  Webmention::Client.send_mention "http://webmention.io/example/webmention", "http://source.example.com/post/100", "http://target.example.com/post/100"
                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  example.rb:19:114: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  Webmention::Client.send_mention "http://webmention.io/example/webmention", "http://source.example.com/post/100", "http://target.example.com/post/100"
                                                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  example.rb:20:1: C: Layout/TrailingBlankLines: 1 trailing blank lines detected. (https://github.com/rubocop-hq/ruby-style-guide#newline-eof)
  Rakefile:13:6: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
  task :default => :test
       ^^^^^^^^^^^
  bin/webmention:3:1: C: Style/SpecialGlobalVars: Prefer $LOAD_PATH over $:. (https://github.com/rubocop-hq/ruby-style-guide#no-cryptic-perlisms)
  $:.unshift(File.join(File.dirname(__FILE__), "/../lib"))
  ^^
  bin/webmention:3:46: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  $:.unshift(File.join(File.dirname(__FILE__), "/../lib"))
                                               ^^^^^^^^^
  bin/webmention:4:9: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  require "webmention"
          ^^^^^^^^^^^^
  bin/webmention:5:9: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  require "link_header"
          ^^^^^^^^^^^^^
  bin/webmention:9:8: C: Style/NilComparison: Prefer the use of the nil? predicate. (https://github.com/rubocop-hq/ruby-style-guide#predicate-methods)
  if url == nil
         ^^
  bin/webmention:10:8: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
    puts "Usage: webmention http://example.com/post/100"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  bin/webmention:14:1: C: Style/NegatedIf: Favor unless over if for negative conditions. (https://github.com/rubocop-hq/ruby-style-guide#unless-for-negatives)
  if !Webmention::Client.valid_http_url?(url) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  bin/webmention:15:8: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
    puts "Not a valid URL"
         ^^^^^^^^^^^^^^^^^
  bin/webmention:30:21: C: Layout/SpaceBeforeBlockBraces: Space missing to the left of {.
  debug links.to_a.map{|m| "\t#{m}"}.join("\n")
                      ^
  bin/webmention:30:21: C: Layout/SpaceInsideBlockBraces: Space between { and | missing.
  debug links.to_a.map{|m| "\t#{m}"}.join("\n")
                      ^^
  bin/webmention:30:34: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
  debug links.to_a.map{|m| "\t#{m}"}.join("\n")
                                   ^
  bin/webmention:32:7: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
  debug ""
        ^^
  bin/webmention:47:9: C: Metrics/BlockNesting: Avoid more than 3 levels of block nesting. (https://github.com/rubocop-hq/ruby-style-guide#three-is-the-number-thou-shalt-count)
          if status_link = link_headers.find_link(['rel', 'status']) ...
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  bin/webmention:47:24: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
          if status_link = link_headers.find_link(['rel', 'status'])
                         ^
  bin/webmention:47:49: C: Style/WordArray: Use %w or %W for an array of words. (https://github.com/rubocop-hq/ruby-style-guide#percent-w)
          if status_link = link_headers.find_link(['rel', 'status'])
                                                  ^^^^^^^^^^^^^^^^^
  bin/webmention:58:9: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
    debug ""
          ^^
  lib/webmention/client.rb:2:3: C: Metrics/ClassLength: Class has too many lines. [117/100]
    class Client ...
    ^^^^^^^^^^^^
  lib/webmention/client.rb:16:7: C: Style/GuardClause: Use a guard clause instead of wrapping the code inside a conditional expression. (https://github.com/rubocop-hq/ruby-style-guide#no-nested-conditionals)
        unless Webmention::Client.valid_http_url? @url
        ^^^^^^
  lib/webmention/client.rb:17:9: C: Style/RaiseArgs: Provide an exception class and message as arguments to raise. (https://github.com/rubocop-hq/ruby-style-guide#exception-class-messages)
          raise ArgumentError.new "#{@url} is not a valid HTTP or HTTPS URI."
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:24:5: C: Metrics/MethodLength: Method has too many lines. [11/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def crawl ...
      ^^^^^^^^^
  lib/webmention/client.rb:26:7: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||. (https://github.com/rubocop-hq/ruby-style-guide#if-as-a-modifier)
        if @url.nil?
        ^^
  lib/webmention/client.rb:27:9: C: Style/RaiseArgs: Provide an exception class and message as arguments to raise. (https://github.com/rubocop-hq/ruby-style-guide#exception-class-messages)
          raise ArgumentError.new "url is nil."
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:27:33: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
          raise ArgumentError.new "url is nil."
                                  ^^^^^^^^^^^^^
  lib/webmention/client.rb:30:22: C: Security/Open: The use of Kernel#open is a serious security risk.
        Nokogiri::HTML(open(self.url)).css('.h-entry a').each do |link|
                       ^^^^
  lib/webmention/client.rb:30:27: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
        Nokogiri::HTML(open(self.url)).css('.h-entry a').each do |link|
                            ^^^^^^^^
  lib/webmention/client.rb:32:9: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||. (https://github.com/rubocop-hq/ruby-style-guide#if-as-a-modifier)
          if Webmention::Client.valid_http_url? link
          ^^
  lib/webmention/client.rb:37:7: C: Style/RedundantReturn: Redundant return detected. (https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return)
        return @links.count
        ^^^^^^
  lib/webmention/client.rb:43:5: C: Metrics/MethodLength: Method has too many lines. [11/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def send_mentions ...
      ^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:44:7: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||. (https://github.com/rubocop-hq/ruby-style-guide#if-as-a-modifier)
        if self.links.nil? or self.links.empty?
        ^^
  lib/webmention/client.rb:44:10: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
        if self.links.nil? or self.links.empty?
           ^^^^^^^^^^
  lib/webmention/client.rb:44:26: C: Style/AndOr: Use || instead of or. (https://github.com/rubocop-hq/ruby-style-guide#no-and-or-or)
        if self.links.nil? or self.links.empty?
                           ^^
  lib/webmention/client.rb:44:29: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
        if self.links.nil? or self.links.empty?
                              ^^^^^^^^^^
  lib/webmention/client.rb:45:9: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
          self.crawl
          ^^^^^^^^^^
  lib/webmention/client.rb:49:7: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
        self.links.each do |link|
        ^^^^^^^^^^
  lib/webmention/client.rb:52:65: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
            cnt += 1 if Webmention::Client.send_mention endpoint, self.url, link
                                                                  ^^^^^^^^
  lib/webmention/client.rb:56:7: C: Style/RedundantReturn: Redundant return detected. (https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return)
        return cnt
        ^^^^^^
  lib/webmention/client.rb:66:5: C: Metrics/MethodLength: Method has too many lines. [17/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.send_mention endpoint, source, target, full_response=false ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:66:27: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.send_mention endpoint, source, target, full_response=false
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:66:66: C: Layout/SpaceAroundEqualsInParameterDefault: Surrounding space missing in default value assignment. (https://github.com/rubocop-hq/ruby-style-guide#spaces-around-equals)
      def self.send_mention endpoint, source, target, full_response=false
                                                                   ^
  lib/webmention/client.rb:68:9: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
          :source => source,
          ^^^^^^^^^^
  lib/webmention/client.rb:69:9: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
          :target => target,
          ^^^^^^^^^^
  lib/webmention/client.rb:69:26: C: Style/TrailingCommaInHashLiteral: Avoid comma after the last item of a hash.
          :target => target,
                           ^
  lib/webmention/client.rb:76:44: C: Style/BracesAroundHashParameters: Redundant curly braces around a hash parameter.
          response = HTTParty.post(endpoint, { ...
                                             ^
  lib/webmention/client.rb:77:11: C: Layout/IndentHash: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
            :body => data
            ^^^^^^^^^^^^^
  lib/webmention/client.rb:77:11: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
            :body => data
            ^^^^^^^^
  lib/webmention/client.rb:78:9: C: Layout/IndentHash: Indent the right brace the same as the first position after the preceding left parenthesis.
          })
          ^
  lib/webmention/client.rb:80:9: C: Style/GuardClause: Use a guard clause instead of wrapping the code inside a conditional expression. (https://github.com/rubocop-hq/ruby-style-guide#no-nested-conditionals)
          if full_response
          ^^
  lib/webmention/client.rb:85:7: C: Style/RescueStandardError: Avoid rescuing without specifying an error class.
        rescue
        ^^^^^^
  lib/webmention/client.rb:96:5: C: Metrics/MethodLength: Method has too many lines. [20/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.supports_webmention? url ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:96:35: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.supports_webmention? url
                                    ^^^
  lib/webmention/client.rb:97:7: C: Style/NegatedIf: Favor unless over if for negative conditions. (https://github.com/rubocop-hq/ruby-style-guide#unless-for-negatives)
        return false if !Webmention::Client.valid_http_url? url
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:99:7: W: Lint/UselessAssignment: Useless assignment to variable - doc. (https://github.com/rubocop-hq/ruby-style-guide#underscore-unused-vars)
        doc = nil
        ^^^
  lib/webmention/client.rb:102:38: C: Style/BracesAroundHashParameters: Redundant curly braces around a hash parameter.
          response = HTTParty.get(url, { ...
                                       ^
  lib/webmention/client.rb:103:11: C: Layout/IndentHash: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
            :timeout => 3,
            ^^^^^^^^^^^^^
  lib/webmention/client.rb:103:11: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
            :timeout => 3,
            ^^^^^^^^^^^
  lib/webmention/client.rb:104:11: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax. (https://github.com/rubocop-hq/ruby-style-guide#hash-literals)
            :headers => {
            ^^^^^^^^^^^
  lib/webmention/client.rb:105:29: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
              'User-Agent' => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36 (https://rubygems.org/gems/webmention)",
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:108:9: C: Layout/IndentHash: Indent the right brace the same as the first position after the preceding left parenthesis.
          })
          ^
  lib/webmention/client.rb:111:9: C: Style/NegatedIf: Favor unless over if for negative conditions. (https://github.com/rubocop-hq/ruby-style-guide#unless-for-negatives)
          if !response.headers['Link'].nil? ...
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:112:22: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
            endpoint = self.discover_webmention_endpoint_from_header response.headers['Link']
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:117:20: C: Style/RedundantSelf: Redundant self detected. (https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required)
          endpoint = self.discover_webmention_endpoint_from_html response.body.to_s
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:125:1: C: Layout/EmptyLinesAroundExceptionHandlingKeywords: Extra empty line detected before the rescue. (https://github.com/rubocop-hq/ruby-style-guide#empty-lines-around-bodies)
  lib/webmention/client.rb:126:7: W: Lint/HandleExceptions: Do not suppress exceptions. (https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions)
        rescue EOFError
        ^^^^^^^^^^^^^^^
  lib/webmention/client.rb:127:7: W: Lint/HandleExceptions: Do not suppress exceptions. (https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions)
        rescue Errno::ECONNRESET
        ^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:130:7: C: Style/RedundantReturn: Redundant return detected. (https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return)
        return false
        ^^^^^^
  lib/webmention/client.rb:133:5: C: Metrics/AbcSize: Assignment Branch Condition size for discover_webmention_endpoint_from_html is too high. [25.2/15] (http://c2.com/cgi/wiki?AbcMetric)
      def self.discover_webmention_endpoint_from_html html ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:133:53: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.discover_webmention_endpoint_from_html html
                                                      ^^^^
  lib/webmention/client.rb:136:64: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
          doc.css('[rel~="webmention"]').css('[href]').attribute("href").value
                                                                 ^^^^^^
  lib/webmention/client.rb:138:75: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
          doc.css('[rel="http://webmention.org/"]').css('[href]').attribute("href").value
                                                                            ^^^^^^
  lib/webmention/client.rb:140:74: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
          doc.css('[rel="http://webmention.org"]').css('[href]').attribute("href").value
                                                                           ^^^^^^
  lib/webmention/client.rb:146:5: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for discover_webmention_endpoint_from_header is too high. [7/6]
      def self.discover_webmention_endpoint_from_header header ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:146:5: C: Metrics/MethodLength: Method has too many lines. [14/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.discover_webmention_endpoint_from_header header ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:146:5: C: Metrics/PerceivedComplexity: Perceived complexity for discover_webmention_endpoint_from_header is too high. [8/7]
      def self.discover_webmention_endpoint_from_header header ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:146:55: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.discover_webmention_endpoint_from_header header
                                                        ^^^^^^
  lib/webmention/client.rb:147:7: C: Style/GuardClause: Use a guard clause instead of wrapping the code inside a conditional expression. (https://github.com/rubocop-hq/ruby-style-guide#no-nested-conditionals)
        if matches = header.match(%r{<([^>]+)>; rel="[^"]*\s?webmention\s?[^"]*"})
        ^^
  lib/webmention/client.rb:147:18: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        if matches = header.match(%r{<([^>]+)>; rel="[^"]*\s?webmention\s?[^"]*"})
                   ^
  lib/webmention/client.rb:147:33: C: Style/RegexpLiteral: Use // around regular expression. (https://github.com/rubocop-hq/ruby-style-guide#percent-r)
        if matches = header.match(%r{<([^>]+)>; rel="[^"]*\s?webmention\s?[^"]*"})
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:149:21: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        elsif matches = header.match(%r{<([^>]+)>; rel=webmention})
                      ^
  lib/webmention/client.rb:149:36: C: Style/RegexpLiteral: Use // around regular expression. (https://github.com/rubocop-hq/ruby-style-guide#percent-r)
        elsif matches = header.match(%r{<([^>]+)>; rel=webmention})
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:150:7: C: Layout/IndentationWidth: Use 2 (not 4) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
            return matches[1]
        ^^^^
  lib/webmention/client.rb:151:21: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        elsif matches = header.match(%r{rel="[^"]*\s?webmention\s?[^"]*"; <([^>]+)>})
                      ^
  lib/webmention/client.rb:151:36: C: Style/RegexpLiteral: Use // around regular expression. (https://github.com/rubocop-hq/ruby-style-guide#percent-r)
        elsif matches = header.match(%r{rel="[^"]*\s?webmention\s?[^"]*"; <([^>]+)>})
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:153:21: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        elsif matches = header.match(%r{rel=webmention; <([^>]+)>})
                      ^
  lib/webmention/client.rb:153:36: C: Style/RegexpLiteral: Use // around regular expression. (https://github.com/rubocop-hq/ruby-style-guide#percent-r)
        elsif matches = header.match(%r{rel=webmention; <([^>]+)>})
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:155:21: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        elsif matches = header.match(%r{<([^>]+)>; rel="http://webmention\.org/?"})
                      ^
  lib/webmention/client.rb:157:21: W: Lint/AssignmentInCondition: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition. (https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition)
        elsif matches = header.match(%r{rel="http://webmention\.org/?"; <([^>]+)>})
                      ^
  lib/webmention/client.rb:160:7: C: Style/RedundantReturn: Redundant return detected. (https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return)
        return false
        ^^^^^^
  lib/webmention/client.rb:168:30: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.valid_http_url? url
                               ^^^
  lib/webmention/client.rb:169:7: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||. (https://github.com/rubocop-hq/ruby-style-guide#if-as-a-modifier)
        if url.is_a? String
        ^^
  lib/webmention/client.rb:173:7: C: Style/RedundantReturn: Redundant return detected. (https://github.com/rubocop-hq/ruby-style-guide#no-explicit-return)
        return (url.is_a? URI::HTTP or url.is_a? URI::HTTPS)
        ^^^^^^
  lib/webmention/client.rb:173:35: C: Style/AndOr: Use || instead of or. (https://github.com/rubocop-hq/ruby-style-guide#no-and-or-or)
        return (url.is_a? URI::HTTP or url.is_a? URI::HTTPS)
                                    ^^
  lib/webmention/client.rb:183:32: C: Style/MethodDefParentheses: Use def with parentheses when there are parameters. (https://github.com/rubocop-hq/ruby-style-guide#method-parens)
      def self.absolute_endpoint endpoint, url
                                 ^^^^^^^^^^^^^
  lib/webmention/version.rb:2:13: C: Style/MutableConstant: Freeze mutable objects assigned to constants.
    VERSION = "0.1.6"
              ^^^^^^^
  lib/webmention/version.rb:2:13: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals)
    VERSION = "0.1.6"
              ^^^^^^^

  8 files inspected, 105 offenses detected
  ```

</details>

## After

> 8 files inspected, 12 offenses detected

<details>
  <summary>View console output from <code>bundle exec rubocop</code></summary>
  
  ```sh
  Inspecting 8 files
  ......W.

  Offenses:

  lib/webmention/client.rb:2:3: C: Metrics/ClassLength: Class has too many lines. [103/100]
    class Client ...
    ^^^^^^^^^^^^
  lib/webmention/client.rb:27:22: C: Security/Open: The use of Kernel#open is a serious security risk.
        Nokogiri::HTML(open(url)).css('.h-entry a').each do |link|
                       ^^^^
  lib/webmention/client.rb:62:5: C: Metrics/MethodLength: Method has too many lines. [12/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.send_mention(endpoint, source, target, full_response = false) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:77:7: C: Style/RescueStandardError: Avoid rescuing without specifying an error class.
        rescue
        ^^^^^^
  lib/webmention/client.rb:88:5: C: Metrics/MethodLength: Method has too many lines. [21/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.supports_webmention?(url) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:121:7: W: Lint/HandleExceptions: Do not suppress exceptions. (https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions)
        rescue EOFError
        ^^^^^^^^^^^^^^^
  lib/webmention/client.rb:122:7: W: Lint/HandleExceptions: Do not suppress exceptions. (https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions)
        rescue Errno::ECONNRESET
        ^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:128:5: C: Metrics/AbcSize: Assignment Branch Condition size for discover_webmention_endpoint_from_html is too high. [25.2/15] (http://c2.com/cgi/wiki?AbcMetric)
      def self.discover_webmention_endpoint_from_html(html) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:142:5: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for discover_webmention_endpoint_from_header is too high. [7/6]
      def self.discover_webmention_endpoint_from_header(header) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:142:5: C: Metrics/MethodLength: Method has too many lines. [14/10] (https://github.com/rubocop-hq/ruby-style-guide#short-methods)
      def self.discover_webmention_endpoint_from_header(header) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:142:5: C: Metrics/PerceivedComplexity: Perceived complexity for discover_webmention_endpoint_from_header is too high. [8/7]
      def self.discover_webmention_endpoint_from_header(header) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  lib/webmention/client.rb:143:7: C: Style/GuardClause: Use a guard clause instead of wrapping the code inside a conditional expression. (https://github.com/rubocop-hq/ruby-style-guide#no-nested-conditionals)
        if (matches = header.match(/<([^>]+)>; rel="[^"]*\s?webmention\s?[^"]*"/))
        ^^

  8 files inspected, 12 offenses detected
  ```

</details>