### PR TITLE
Ensuring we only select HTTPS? urls for webmention

### DIFF
--- a/lib/webmention/parsers/html_parser.rb
+++ b/lib/webmention/parsers/html_parser.rb
@@ -24,15 +24,18 @@ module Webmention
         @doc ||= Nokogiri::HTML(response_body)
       end
 
+      HTTP_URLS_REGEXP = %r{^https?://}.freeze
+
       # Parse an HTML string for URLs
       #
-      # @return [Array] the URLs
+      # @return [Array] the URLs that have the HTTP or HTTPS URI scheme
       def parse_response_body
         CSS_SELECTORS_MAP
           .each_with_object([]) { |(*args), array| array << search_node(*args) }
           .flatten
           .map { |url| Absolutely.to_abs(base: response_url, relative: url) }
           .uniq
+          .select { |url| HTTP_URLS_REGEXP.match?(url) }
       end
 
       def root_node

--- a/test/support/test_fixtures.rb
+++ b/test/support/test_fixtures.rb
@@ -13,6 +13,7 @@ module TestFixtures
           <p><a href="https://target.example.com/post/2">Link to Target 2</a></p>
           <p><a href="https://target.example.com/post/2">Duplicate Link to Target 2</a></p>
           <p><img src="https://target.example.com/image.jpg" srcset="https://target.example.com/image-1x.jpg, https://target.example.com/image-2x.jpg 2x"></p>
+          <p><a href="mailto:email@example.com">Invalid Link</a></p>
         </main>
       </body>
     </html>'.freeze
@@ -30,6 +31,7 @@ module TestFixtures
           <p><a href="https://target.example.com/post/1">Link to Target 1</a></p>
           <p><a href="https://target.example.com/post/2">Link to Target 2</a></p>
           <p><a href="/post/1">Relative Link to Source 1</a></p>
+          <p><a href="mailto:email@example.com">Invalid Link</a></p>
         </main>
       </body>
     </html>'.freeze
@@ -42,6 +44,7 @@ module TestFixtures
       <body>
         <main class="h-entry">
           <p>Hello, world!</p>
+          <p><a href="mailto:email@example.com">Invalid Link</a></p>
         </main>
       </body>
     </html>'.freeze


### PR DESCRIPTION
When we parse a response body, and get an HREF that is a "mailto",
this will cause problems when we then go to `send_all_mentions`.

When we call `Webmention::Client#send_all_mentions`, and one of the
URLs is a "mailto", the [IndieWeb::Endpoints::Client][1] raises
an exception.

This commit ensures that we only treat HTTPS? as webmention
candidates.

[1]:https://github.com/indieweb/indieweb-endpoints-ruby/blob/master/lib/indieweb/endpoints/client.rb#L7