### PR TITLE
Adding logging to WebMention::Client

### DIFF
--- a/lib/webmention.rb
+++ b/lib/webmention.rb
@@ -18,12 +18,12 @@ require 'webmention/services/node_parser_service'
 
 module Webmention
   class << self
-    def client(source)
-      Client.new(source)
+    def client(source, **kwargs)
+      Client.new(source, **kwargs)
     end
 
-    def send_mention(source, target)
-      client(source).send_mention(target)
+    def send_mention(source, target, **kwargs)
+      client(source, **kwargs).send_mention(target)
     end
   end
 end

--- a/test/lib/webmention/client_mentioned_urls_test.rb
+++ b/test/lib/webmention/client_mentioned_urls_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 describe Webmention::Client, :mentioned_urls do
   let(:url) { 'https://example.com' }
+  let(:logger) { NullLogger.new }
 
-  let(:client) { Webmention::Client.new(url) }
+  let(:client) { Webmention::Client.new(url, logger: logger) }
 
   let(:stubbed_request) { stub_request(:get, url) }
 

--- a/test/lib/webmention/client_send_all_mentions_test.rb
+++ b/test/lib/webmention/client_send_all_mentions_test.rb
@@ -3,12 +3,13 @@ require 'test_helper'
 describe Webmention::Client, :send_all_mentions do
   let(:source_url) { 'https://source.example.com' }
   let(:target_url) { 'https://target.example.com' }
+  let(:logger) { NullLogger.new }
 
   let :http_response_headers do
     { 'Content-Type': 'text/html' }
   end
 
-  let(:client) { Webmention::Client.new(source_url) }
+  let(:client) { Webmention::Client.new(source_url, logger: logger) }
 
   describe 'when no mentioned URLs found' do
     before do

--- a/test/lib/webmention/client_send_mention_test.rb
+++ b/test/lib/webmention/client_send_mention_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 describe Webmention::Client, :send_mention do
   let(:source_url) { 'https://source.example.com' }
   let(:target_url) { 'https://target.example.com' }
+  let(:logger) { NullLogger.new }
 
-  let(:client) { Webmention::Client.new(source_url) }
+  let(:client) { Webmention::Client.new(source_url, logger: logger) }
 
   describe 'when rescuing an IndieWeb::Endpoints::ConnectionError' do
     before do

--- a/test/lib/webmention_send_mention_test.rb
+++ b/test/lib/webmention_send_mention_test.rb
@@ -4,6 +4,7 @@ describe Webmention, :send_mention do
   let(:source_url) { 'https://source.example.com' }
   let(:target_url) { 'https://target.example.com' }
   let(:target_endpoint_url) { "#{target_url}/webmention" }
+  let(:logger) { NullLogger.new }
 
   describe 'when no endpoint found' do
     before do
@@ -13,7 +14,7 @@ describe Webmention, :send_mention do
     end
 
     it 'returns nil' do
-      _(Webmention.send_mention(source_url, target_url)).must_be_nil
+      _(Webmention.send_mention(source_url, target_url, logger: logger)).must_be_nil
     end
   end
 
@@ -31,7 +32,7 @@ describe Webmention, :send_mention do
     end
 
     it 'returns an HTTP::Response' do
-      _(Webmention.send_mention(source_url, target_url)).must_be_instance_of(HTTP::Response)
+      _(Webmention.send_mention(source_url, target_url, logger: logger)).must_be_instance_of(HTTP::Response)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,3 +10,14 @@ Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
 require_relative 'support/test_fixtures'
 
 require 'webmention'
+
+require 'logger'
+
+# Reduce the chatter of logging for tests
+class NullLogger
+  # To get the Logger API you can run this:
+  #   (Logger.instance_methods.sort - Logger.methods).sort
+  (Logger.instance_methods.sort - Logger.methods).each do |method_name|
+    define_method(method_name) { |*_args| }
+  end
+end


### PR DESCRIPTION
Prior to this commit, when I called `Webmention::Client#send_all_mentions`,
I had no idea which URL was throwing an exception.

With logging, I was able to track down that the `Webmention::Client`
considered a `mailto` URL as something to attempt to send a mention
to.

By adding the logging, I can see the candidate URLs for sending a
webmention. I can also see if the candidate URL has a webmention
end point or not.