### PR TITLE
Update gem metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+> [!NOTE]
+> From v8.0.0, changes are documented using [GitHub Releases](https://github.com/indieweb/webmention-client-ruby/releases). For a given release, metadata on RubyGems.org will link to that version's Release page.
+
 ## 7.0.0 / 2022-11-09
 
 - Refactor HTML and JSON parser classes (ec58206 and 6818c05)

--- a/lib/webmention/version.rb
+++ b/lib/webmention/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Webmention
-  VERSION = "7.0.0"
+  VERSION = "8.0.0"
 end

--- a/webmention.gemspec
+++ b/webmention.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/CHANGELOG.md",
-    "rubygems_mfa_required" => "true"
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }
 
   spec.add_runtime_dependency "http", "~> 5.0"

--- a/webmention.gemspec
+++ b/webmention.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",
-    "changelog_uri" => "#{spec.homepage}/blob/v#{spec.version}/CHANGELOG.md",
+    "changelog_uri" => "#{spec.homepage}/releases/tag/v#{spec.version}",
     "rubygems_mfa_required" => "true",
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }


### PR DESCRIPTION
## Description

Updates gem metadata with improved links to source code and release notes. The next version, v8.0.0, will use GitHub Releases. The metadata update here will link properly to the GitHub Releases page for a given version when it's released to RubyGems.org, etc.

## Commits

- Add source_code_uri to gem metadata
- Update metadata and CHANGELOG noting GitHub Releases usage
- Bump version to v8.0.0
