### PR TITLE
Correct name of ruby gem in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add webmention-client-ruby to your project's `Gemfile` and run `bundle install`:
 ```ruby
 source "https://rubygems.org"
 
-gem "webmention-client"
+gem "webmention"
 ```
 
 ## Usage


### PR DESCRIPTION
The name of the gem is currently incorrect in the README. This PR fixes that.