### PR TITLE
Add newer rubies to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
I think these should both pass.

Separately, I think this issue from `http-cookie` dep https://github.com/sparklemotion/http-cookie/issues/62 winds up impacting `Webmention` when it runs on latest ... presumably they will sort that out soon.